### PR TITLE
Release for Mantid developer meeting 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ python-overrides-*-py2.py3-none-any.whl
 py_src/README.md
 bk
 tmp
+fonts
+icons
+881c86876af63b732063d7bdd51bb226.png
+f4cfc6708cf6bfc17d4b1e775f594ae2.png
 
 mantid/mantid
 mantid/pychop

--- a/diffs/mantidqtinterfaces.diff
+++ b/diffs/mantidqtinterfaces.diff
@@ -10,6 +10,18 @@ diff -urd mantid/mantidqtinterfaces/DGSPlanner/ClassicUBInputWidget.py py_src/ma
  
          # connections
          self._edita.textEdited.connect(self.check_state_latt)
+@@ -192,7 +192,10 @@
+             color = "#ff0000"
+         senderWidget.setStyleSheet("QLineEdit { background-color: %s }" % color)
+         if state == QtGui.QValidator.Acceptable:
+-            self.validateAll()
++            try:
++                self.validateAll()
++            except ValueError:
++                pass
+
+     def validateAll(self):
+         self.latt_a = float(self._edita.text())
 diff -urd mantid/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py py_src/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py
 --- py_src/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py	2025-06-19 00:31:00.171042586 +0100
 +++ py_src/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py	2025-06-19 00:55:08.033042672 +0100

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <title>OS.js UMD Standalone Example</title>
   <link rel="stylesheet" href="src/inswae.css">
+  <link rel="stylesheet" href="src/mpl.css">
   <script>
     window.console = window.console || function(t) {};
   </script>

--- a/py_src/inswae/__init__.py
+++ b/py_src/inswae/__init__.py
@@ -30,7 +30,6 @@ def create_pychop():
     app = QApplication([])
     window = PyChopGui.PyChopGui(None, None)
     window._style = {'width':950, 'height':650}
-    window.show()
     return app.exec()
 
 def create_dgsplanner():

--- a/py_src/inswae/mplbackend.py
+++ b/py_src/inswae/mplbackend.py
@@ -1,0 +1,73 @@
+from js import ImageData, document
+from matplotlib import interactive
+from matplotlib.backend_bases import FigureManagerBase, NavigationToolbar2, _Backend
+from matplotlib.backends import backend_agg
+import mpljs
+from pyodide.ffi import create_proxy
+from pyodide.ffi.wrappers import set_timeout
+
+interactive(True)
+
+class FigureCanvasJsAgg(backend_agg.FigureCanvasAgg):
+    supports_blit = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._idle_scheduled = False
+        self._id = "matplotlib_" + hex(id(self))[2:]
+        self._title = ""
+        self._jsfigure = None
+
+    def show(self, *args, **kwargs):
+        width, height = self.get_width_height()
+        if self._jsfigure is None:
+            self._jsfigure = mpljs.Figure.new(self._id, self._create_root_element(), width, height, self._title)
+            if self.toolbar is not None:
+                self._jsfigure.insertBefore(self.toolbar.get_element(), self._figure.message)
+        self.draw()
+ 
+    def draw(self):
+        if self._jsfigure is None:
+            return
+        # Render the figure using Agg
+        self._idle_scheduled = True
+        orig_dpi = self.figure.dpi
+        if self._jsfigure.ratio != 1:
+            self.figure.dpi *= self._jsfigure.ratio
+        pixels_proxy = None
+        pixels_buf = None
+        try:
+            super().draw()
+            # Copy the image buffer to the canvas
+            width, height = self.get_width_height()
+            canvas = self._jsfigure.canvas
+            if canvas is None:
+                return
+            pixels = self.buffer_rgba().tobytes()
+            pixels_proxy = create_proxy(pixels)
+            pixels_buf = pixels_proxy.getBuffer("u8clamped")
+            image_data = ImageData.new(pixels_buf.data, width, height)
+            canvas.getContext("2d").putImageData(image_data, 0, 0)
+        finally:
+            self.figure.dpi = orig_dpi
+            self._idle_scheduled = False
+            if pixels_proxy:
+                pixels_proxy.destroy()
+            if pixels_buf:
+                pixels_buf.release()
+
+    def draw_idle(self):
+        if not self._idle_scheduled:
+            self._idle_scheduled = True
+            set_timeout(self.draw, 1)
+
+    def _create_root_element(self):
+        div = document.createElement("div")
+        mpl_target = getattr(document, "pyodideMplTarget", document.body)
+        mpl_target.appendChild(div)
+        return div
+
+
+@_Backend.export
+class _BackendJsAgg(_Backend):
+    FigureCanvas = FigureCanvasJsAgg

--- a/py_src/inswae/mplbackend.py
+++ b/py_src/inswae/mplbackend.py
@@ -1,12 +1,26 @@
-from js import ImageData, document
+from io import BytesIO
+from js import ImageData, document, alert
 from matplotlib import interactive
-from matplotlib.backend_bases import FigureManagerBase, NavigationToolbar2, _Backend
+from matplotlib.backend_bases import FigureManagerBase, NavigationToolbar2, _Backend, KeyEvent, LocationEvent, MouseEvent, ResizeEvent
 from matplotlib.backends import backend_agg
 import mpljs
-from pyodide.ffi import create_proxy
+import base64
+from pyodide.ffi import create_proxy, to_js
 from pyodide.ffi.wrappers import set_timeout
+from pathlib import Path
 
 interactive(True)
+
+_SPECIAL_KEYS_LUT = {'Alt': 'alt', 'AltGraph': 'alt', 'CapsLock': 'caps_lock', 'NumLock': 'num_lock', 'ScrollLock': 'scroll_lock',
+                     'ArrowDown': 'down', 'ArrowLeft': 'left', 'ArrowRight': 'right', 'ArrowUp': 'up'}
+_SPECIAL_KEYS = ['Control', 'Meta', 'Shift', 'Super', 'Enter', 'Tab', 'End', 'Home', 'PageDown', 'PageUp', 'Backspace', 'Delete', 'Insert',
+                 'Escape', 'Pause', 'Select', 'Dead', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12']
+def _handle_key(key):
+    value = key[key.index('k') + 1:]
+    if 'shift+' in key and len(value) == 1:
+        key = key.replace('shift+', '')
+    value = _SPECIAL_KEYS_LUT.get(value, value.lower() if value in _SPECIAL_KEYS else value) 
+    return key[:key.index('k')] + value 
 
 class FigureCanvasJsAgg(backend_agg.FigureCanvasAgg):
     supports_blit = False
@@ -16,31 +30,31 @@ class FigureCanvasJsAgg(backend_agg.FigureCanvasAgg):
         self._idle_scheduled = False
         self._id = "matplotlib_" + hex(id(self))[2:]
         self._title = ""
-        self._jsfigure = None
+        self.jsfig = None
+        self._last_mouse_xy = (None, None)
+        self.toolbar = NavigationToolbar2JsAgg(self)
 
     def show(self, *args, **kwargs):
         width, height = self.get_width_height()
-        if self._jsfigure is None:
-            self._jsfigure = mpljs.Figure.new(self._id, self._create_root_element(), width, height, self._title)
-            if self.toolbar is not None:
-                self._jsfigure.insertBefore(self.toolbar.get_element(), self._figure.message)
+        if self.jsfig is None:
+            self.jsfig = mpljs.Figure.new(create_proxy(self), self._create_root_element(), width, height)
         self.draw()
  
     def draw(self):
-        if self._jsfigure is None:
+        if self.jsfig is None:
             return
         # Render the figure using Agg
         self._idle_scheduled = True
         orig_dpi = self.figure.dpi
-        if self._jsfigure.ratio != 1:
-            self.figure.dpi *= self._jsfigure.ratio
+        if self.jsfig.ratio != 1:
+            self.figure.dpi *= self.jsfig.ratio
         pixels_proxy = None
         pixels_buf = None
         try:
             super().draw()
             # Copy the image buffer to the canvas
             width, height = self.get_width_height()
-            canvas = self._jsfigure.canvas
+            canvas = self.jsfig.canvas
             if canvas is None:
                 return
             pixels = self.buffer_rgba().tobytes()
@@ -61,12 +75,93 @@ class FigureCanvasJsAgg(backend_agg.FigureCanvasAgg):
             self._idle_scheduled = True
             set_timeout(self.draw, 1)
 
+    def handle_mouse(self, e_type, x, y, button, step, modifiers, guiEvent):
+        y = self.get_renderer().height - y
+        self._last_mouse_xy = x, y
+        # JavaScript button numbers and Matplotlib button numbers are off by 1.
+        button = button + 1
+        if e_type in ['button_press', 'button_release']:
+            MouseEvent(e_type + '_event', self, x, y, button, modifiers=modifiers, guiEvent=guiEvent)._process()
+        elif e_type == 'dblclick':
+            MouseEvent('button_press_event', self, x, y, button, dblclick=True, modifiers=modifiers, guiEvent=guiEvent)._process()
+        elif e_type == 'scroll':
+            MouseEvent('scroll_event', self, x, y, step=step, modifiers=modifiers, guiEvent=guiEvent)._process()
+        elif e_type == 'motion_notify':
+            MouseEvent(e_type + '_event', self, x, y, modifiers=modifiers, guiEvent=guiEvent)._process()
+        elif e_type in ['figure_enter', 'figure_leave']: LocationEvent(e_type + '_event', self, x, y, modifiers=modifiers, guiEvent=guiEvent)._process()
+
+    def handle_key(self, e_type, key, guiEvent):
+        KeyEvent(e_type + '_event', self, _handle_key(key), *self._last_mouse_xy, guiEvent=guiEvent)._process()
+
+    def handle_toolbar_button(self, event):
+        getattr(self.toolbar, event)()
+
+    def handle_save(self, filetype):
+        mimetype = mimetypes.types_map.get(f".{filetype}")
+        if mimetype is None:
+            alert(f"Cannot download plot, unable to determine mimetype for '{filetype}'")
+            return
+        element = document.createElement('a')
+        data = BytesIO()
+        self.figure.savefig(data, format=filetype)
+        element.setAttribute("href", "data:{};base64,{}".format(mimetype, base64.b64encode(data.getvalue()).decode("ascii")))
+        element.setAttribute("download", f"plot{self._id}.{format}")
+        element.style.display = "none"
+        document.body.appendChild(element)
+        element.click()
+        document.body.removeChild(element)
+
+    def get_toolbar_items(self):
+        return to_js([['']*4 if v[0] is None else list(v) for v in self.toolbar.toolitems])
+
+    def get_toolbar_image(self, image):
+        filename = Path(backend_agg.__file__).parent.parent / f"mpl-data/images/{image}.png"
+        return to_js(filename.read_bytes())
+
     def _create_root_element(self):
         div = document.createElement("div")
         mpl_target = getattr(document, "pyodideMplTarget", document.body)
         mpl_target.appendChild(div)
         return div
 
+_ALLOWED_TOOL_ITEMS = {'home', 'back', 'forward', 'pan', 'zoom', 'download', None}
+
+class NavigationToolbar2JsAgg(NavigationToolbar2):
+    toolitems = [v for v in (*NavigationToolbar2.toolitems, ('Download', 'Download plot', 'filesave', 'download'))
+        if v[3] in _ALLOWED_TOOL_ITEMS]
+
+    def __init__(self, canvas):
+        self.message = ''
+        super().__init__(canvas)
+
+    def set_message(self, message):
+        if message != self.message:
+            self.canvas.jsfig.handle_message(message)
+        self.message = message
+
+    def draw_rubberband(self, event, x0, y0, x1, y1):
+        self.canvas.jsfig.handle_rubberband(x0, x1, y0, y1)
+
+    def remove_rubberband(self):
+        self.canvas.jsfig.handle_rubberband(-1, -1, -1, -1)
+
+    def save_figure(self, *args):
+        """Save the current figure"""
+        self.canvas.handle_save('png')
+
+    def pan(self):
+        super().pan()
+        self.canvas.jsfig.handle_navigate_mode(self.mode.name)
+
+    def zoom(self):
+        super().zoom()
+        self.canvas.jsfig.handle_navigate_mode(self.mode.name)
+
+    def set_history_buttons(self):
+        can_backward = self._nav_stack._pos > 0
+        can_forward = self._nav_stack._pos < len(self._nav_stack) - 1
+        if self.canvas.jsfig is not None:
+            self.canvas.jsfig.handle_history_buttons(can_backward, can_forward);
 
 @_Backend.export
 class _BackendJsAgg(_Backend):

--- a/py_src/inswae/mplbackend.py
+++ b/py_src/inswae/mplbackend.py
@@ -5,6 +5,7 @@ from matplotlib.backend_bases import FigureManagerBase, NavigationToolbar2, _Bac
 from matplotlib.backends import backend_agg
 import mpljs
 import base64
+import mimetypes
 from pyodide.ffi import create_proxy, to_js
 from pyodide.ffi.wrappers import set_timeout
 from pathlib import Path

--- a/py_src/mantidqt/MPLwidgets.py
+++ b/py_src/mantidqt/MPLwidgets.py
@@ -1,43 +1,67 @@
 import js
+import uuid
+from pyodide.code import run_js
 from qtpy.QtWidgets import QWidget
-from matplotlib_pyodide.html5_canvas_backend import FigureCanvasHTMLCanvas, NavigationToolbar2HTMLCanvas
+from matplotlib.backends.backend_webagg import FigureManagerWebAgg, WebAggApplication
+from matplotlib.backends.backend_webagg_core import FigureCanvasWebAggCore, NavigationToolbar2WebAgg
 
-class FigureCanvas(FigureCanvasHTMLCanvas, QWidget):
-    def __init__(self, *arg, **kwargs):
-        FigureCanvasHTMLCanvas.__init__(self, *arg, **kwargs)
-        QWidget.__init__(self)
+FIGNUM = 0
+
+class FigureCanvas(FigureCanvasWebAggCore, QWidget):
+    def __init__(self, figure=None):
+        super().__init__(figure=figure)
         self._element = 'iframe'
         self._style = {'border':'none'}
-        self._actions = {'onload':self._onloadWrapper()}
-        self.toolbar = NavigationToolbar2HTMLCanvas(self)
+        self._id = f'mplfig{str(uuid.uuid4())[:6]}'
+        WebAggApplication.initialize()
+        self.js_fig = None
+        self._num = 0
         self._init = False
-        self._div = js.document.getElementById(self._id + '_rootdiv')
+        self._div = js.document.getElementById(self._id)
         if not self._div:
             self._div = js.document.createElement('div')
-            self._div.id = self._id + '_rootdiv'
-    def _onloadWrapper(self):
+            self._div.id = self._id
+            js.document.body.append(self._div)
+            self._div.style.visibility = 'hidden'
         def loadWrap(event):
-            if not self._init:
+            if not self._init or not js.document.getElementById(self._id):
                 self._init = True
+                self._div.remove()
+                self._div.style.visibility = 'visible'
                 event.target.parentNode.append(self._div)
                 event.target.remove()
                 self.show()
-        return loadWrap
+        self._actions = {'onload': loadWrap}
+    def _get_manager(self):
+        if self.manager is None:
+            global FIGNUM
+            self.manager = FigureManagerWebAgg(self, FIGNUM)
+            self._num = FIGNUM
+            FIGNUM += 1
+    def draw(self):
+        self._get_manager()
+        FigureCanvasWebAggCore.draw(self)
     def show(self):
-        # Both FigureCanvasHTMLCanvas and QWidget have show()
-        FigureCanvasHTMLCanvas.show(self) 
+        self._get_manager()
+        fignum = self._num
+        if self.js_fig is None:
+            js_code = \
+                """
+                var websocket_type = mpl.get_websocket_type();
+                var fig = new mpl.figure(fig_id, new websocket_type(fig_id), null, document.getElementById(parent_id));
+                fig;
+                """
+            js_code = f"var fig_id = '{fignum}'; var parent_id = '{self._id}'; " + js_code
+            self.js_fig = run_js(js_code)
+            web_socket = WebAggApplication.MockPythonWebSocket(self.manager, self.js_fig.ws)
+            web_socket.open(fignum)
     def updateGeometry(self):
         pass
-    def _create_root_element(self):
-        # Overrides so it is not included in the "pyodideMplTarget" element
-        return self._div
 
 FigureCanvasQTAgg = FigureCanvas
 
 # Never render navigation toolbar separately, always bundle it a FigureCanvas
-class NavigationToolbar2QT():
-    def __init__(self, canvas, parent, coordinates=True):
-        pass
-    def isVisible(self):
-        return False
-    def hide(self): ...
+class NavigationToolbar2QT(NavigationToolbar2WebAgg, QWidget):
+    def __init__(self, canvas, parent=None, coordinates=True):
+        NavigationToolbar2WebAgg.__init__(self, canvas)
+        QWidget.__init__(self, parent)

--- a/py_src/mantidqt/MPLwidgets.py
+++ b/py_src/mantidqt/MPLwidgets.py
@@ -1,67 +1,43 @@
 import js
-import uuid
-from pyodide.code import run_js
 from qtpy.QtWidgets import QWidget
-from matplotlib.backends.backend_webagg import FigureManagerWebAgg, WebAggApplication
-from matplotlib.backends.backend_webagg_core import FigureCanvasWebAggCore, NavigationToolbar2WebAgg
+from matplotlib.backends.wasm_backend import FigureCanvasAggWasm, NavigationToolbar2AggWasm
 
-FIGNUM = 0
-
-class FigureCanvas(FigureCanvasWebAggCore, QWidget):
-    def __init__(self, figure=None):
-        super().__init__(figure=figure)
+class FigureCanvas(FigureCanvasAggWasm, QWidget):
+    def __init__(self, *arg, **kwargs):
+        FigureCanvasAggWasm.__init__(self, *arg, **kwargs)
+        QWidget.__init__(self)
         self._element = 'iframe'
         self._style = {'border':'none'}
-        self._id = f'mplfig{str(uuid.uuid4())[:6]}'
-        WebAggApplication.initialize()
-        self.js_fig = None
-        self._num = 0
+        self._actions = {'onload':self._onloadWrapper()}
+        self.toolbar = NavigationToolbar2AggWasm(self)
         self._init = False
-        self._div = js.document.getElementById(self._id)
+        self._div = js.document.getElementById(self._id + '_rootdiv')
         if not self._div:
             self._div = js.document.createElement('div')
-            self._div.id = self._id
-            js.document.body.append(self._div)
-            self._div.style.visibility = 'hidden'
+            self._div.id = self._id + '_rootdiv'
+    def _onloadWrapper(self):
         def loadWrap(event):
-            if not self._init or not js.document.getElementById(self._id):
+            if not self._init or not js.document.getElementById(self._id + '_rootdiv'):
                 self._init = True
-                self._div.remove()
-                self._div.style.visibility = 'visible'
                 event.target.parentNode.append(self._div)
                 event.target.remove()
                 self.show()
-        self._actions = {'onload': loadWrap}
-    def _get_manager(self):
-        if self.manager is None:
-            global FIGNUM
-            self.manager = FigureManagerWebAgg(self, FIGNUM)
-            self._num = FIGNUM
-            FIGNUM += 1
-    def draw(self):
-        self._get_manager()
-        FigureCanvasWebAggCore.draw(self)
+        return loadWrap
     def show(self):
-        self._get_manager()
-        fignum = self._num
-        if self.js_fig is None:
-            js_code = \
-                """
-                var websocket_type = mpl.get_websocket_type();
-                var fig = new mpl.figure(fig_id, new websocket_type(fig_id), null, document.getElementById(parent_id));
-                fig;
-                """
-            js_code = f"var fig_id = '{fignum}'; var parent_id = '{self._id}'; " + js_code
-            self.js_fig = run_js(js_code)
-            web_socket = WebAggApplication.MockPythonWebSocket(self.manager, self.js_fig.ws)
-            web_socket.open(fignum)
+        # Both FigureCanvasAggWasm and QWidget have show()
+        FigureCanvasAggWasm.show(self) 
     def updateGeometry(self):
         pass
+    def _create_root_element(self):
+        # Overrides so it is not included in the "pyodideMplTarget" element
+        return self._div
 
 FigureCanvasQTAgg = FigureCanvas
 
 # Never render navigation toolbar separately, always bundle it a FigureCanvas
-class NavigationToolbar2QT(NavigationToolbar2WebAgg, QWidget):
-    def __init__(self, canvas, parent=None, coordinates=True):
-        NavigationToolbar2WebAgg.__init__(self, canvas)
-        QWidget.__init__(self, parent)
+class NavigationToolbar2QT():
+    def __init__(self, canvas, parent, coordinates=True):
+        pass
+    def isVisible(self):
+        return False
+    def hide(self): ...

--- a/py_src/mantidqt/MPLwidgets.py
+++ b/py_src/mantidqt/MPLwidgets.py
@@ -1,15 +1,14 @@
 import js
 from qtpy.QtWidgets import QWidget
-from matplotlib.backends.wasm_backend import FigureCanvasAggWasm, NavigationToolbar2AggWasm
+from inswae.mplbackend import FigureCanvasJsAgg
 
-class FigureCanvas(FigureCanvasAggWasm, QWidget):
+class FigureCanvas(FigureCanvasJsAgg, QWidget):
     def __init__(self, *arg, **kwargs):
-        FigureCanvasAggWasm.__init__(self, *arg, **kwargs)
+        FigureCanvasJsAgg.__init__(self, *arg, **kwargs)
         QWidget.__init__(self)
         self._element = 'iframe'
         self._style = {'border':'none'}
         self._actions = {'onload':self._onloadWrapper()}
-        self.toolbar = NavigationToolbar2AggWasm(self)
         self._init = False
         self._div = js.document.getElementById(self._id + '_rootdiv')
         if not self._div:
@@ -24,8 +23,8 @@ class FigureCanvas(FigureCanvasAggWasm, QWidget):
                 self.show()
         return loadWrap
     def show(self):
-        # Both FigureCanvasAggWasm and QWidget have show()
-        FigureCanvasAggWasm.show(self) 
+        # Both FigureCanvasJsAgg and QWidget have show()
+        FigureCanvasJsAgg.show(self) 
     def updateGeometry(self):
         pass
     def _create_root_element(self):

--- a/py_src/qtpy/QtWidgets.py
+++ b/py_src/qtpy/QtWidgets.py
@@ -62,7 +62,7 @@ class QApplication():
                 def createApp(content, win):
                     renderfn = create_proxy(self.window._layout.render_function)
                     return app(toObj({'stateid':0}), toObj({'change':create_proxy(state_change)}), renderfn, content)
-                if self.window._jswindow is None:
+                if self.window._jswindow is None or self.window._jswindow.destroyed:
                     self.window._jswindow = proc.createWindow(toObj({'title': self.window._title, 'dimension':self.window._size()})).render(createApp)
             return callback
 
@@ -243,7 +243,9 @@ class QWidget():
             if self._layout is None:
                 raise RuntimeError('Custom top level widget has no layout')
             self._layout._styles = {**self._style, **self._framestyle}
-            if (QAPP is None or QAPP.window is not None) and self._jswindow is None:
+            if QAPP is None or QAPP.window is not None:
+                if self._jswindow is not None and self._jswindow.destroyed is False:
+                    return
                 window_data = toObj({'title': self._title, 'dimension':self._size()})
                 def createApp(content, win):
                     renderfn = create_proxy(self._layout.render_function)

--- a/src/inswae.css
+++ b/src/inswae.css
@@ -99,3 +99,27 @@
   visibility: visible;
   opacity: 1;
 }
+
+button.matplotlib-toolbar-button {
+    font-size: 14px;
+    color: #495057;
+    text-transform: uppercase;
+    background: #e9ecef;
+    padding: 9px 18px;
+    border: 1px solid #fff;
+    border-radius: 4px;
+    transition-duration: 0.4s;
+}
+
+button.matplotlib-toolbar-button#text {
+    font-family: -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Fira Sans", "Droid Sans", "Helvetica Neue", Arial,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+}
+
+button.matplotlib-toolbar-button:hover {
+    color: #fff;
+    background: #495057;
+}

--- a/src/inswae.js
+++ b/src/inswae.js
@@ -133,7 +133,7 @@ async function init_python() {
      shortobj + '"icon": "favicon.ico", "path": "apps:/MSlice", "filename": "MSlice" }'
   +']');
   window.osjs.make('osjs/settings').set('osjs/desktop', 'iconview.enabled', true).save()
-  url_to_fs("MAR25352_Ei180.00meV.nxspe", "/home/pyodide/MAR25352_Ei180.00meV.nxspe");
+  //url_to_fs("MAR25352_Ei180.00meV.nxspe", "/home/pyodide/MAR25352_Ei180.00meV.nxspe");
 /*
   const exm = window.pyodide.runPython(`
     # Test script of all currently implemented widgets

--- a/src/inswae.js
+++ b/src/inswae.js
@@ -90,7 +90,7 @@ async function url_to_fs(urlpath, fspath) {
   xhr.send();
   xhr.onload = () => { if (xhr.status == 200) { 
     let arraybuf = new Uint8Array(xhr.response);
-    fs.writeFile(fspath, arraybuf);
+    window.pyodide.FS.writeFile(fspath, arraybuf);
   } }
 };
 

--- a/src/inswae.js
+++ b/src/inswae.js
@@ -92,15 +92,15 @@ async function init_python() {
   window.pyodide.registerJsModule("hyperapp", {h:h, text:text, app:app});
   window.pyodide.registerJsModule("jswidgets", jswidgets);
   const fs = window.pyodide.FS;
+  // Loads Python wheels
+  for (const pkg of ["numpy", "pyyaml", "matplotlib"]) {//, "scipy"]) {
+    await window.pyodide.loadPackage(pkg);
+  }
   // Installs mantid
   await window.pyodide.loadPackage("micromantid-0.0.1-cp312-cp312-pyodide_2024_0_wasm32.whl");
   // Copies files in the overrides folder to Python site-packages folder
   await window.pyodide.loadPackage("python-overrides-1.0.0-py2.py3-none-any.whl");
   await window.pyodide.loadPackage("mslice-1.0.0-py2.py3-none-any.whl");
-  // Loads Python wheels
-  for (const pkg of ["numpy", "pyyaml", "matplotlib"]) {//, "scipy"]) {
-    await window.pyodide.loadPackage(pkg);
-  }
   // Imports matplotlib and Mantid now to save time on initialising apps
   await window.pyodide.runPython(`
       import matplotlib.pyplot

--- a/src/inswae.js
+++ b/src/inswae.js
@@ -6,13 +6,14 @@ import htm from 'https://esm.sh/htm'
 const html = htm.bind(Preact.h)
 import "https://cdn.plot.ly/plotly-2.27.0.min.js";
 */
-import "https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide.js";
+import "https://cdn.jsdelivr.net/pyodide/v0.27.7/full/pyodide.js";
 import "https://cdn.jsdelivr.net/npm/@osjs/gui/dist/main.js";
 import "https://cdn.jsdelivr.net/npm/@osjs/client/dist/main.js";
 import "https://cdn.jsdelivr.net/npm/@osjs/panels/dist/main.js";
 import "https://cdn.jsdelivr.net/npm/@osjs/dialogs/dist/main.js";
 import EmscriptenFSAdapter from "./emfs-adapter.js";
 import { jswidgets } from "./widgets.js";
+import { mpljs } from "./mpl.js";
 
 console.log("Imported JS from CDNs")
 
@@ -102,13 +103,14 @@ async function init_python() {
   window.pyodide.registerJsModule("osjsDialogs", osjsDialogs);
   window.pyodide.registerJsModule("hyperapp", {h:h, text:text, app:app});
   window.pyodide.registerJsModule("jswidgets", jswidgets);
+  window.pyodide.registerJsModule("mpljs", mpljs);
   const fs = window.pyodide.FS;
   // Loads Python wheels
   for (const pkg of ["numpy", "pyyaml", "matplotlib"]) {//, "scipy"]) {
     await window.pyodide.loadPackage(pkg);
   }
   // Installs mantid
-  await window.pyodide.loadPackage("micromantid-0.0.1-cp312-cp312-pyodide_2024_0_wasm32.whl");
+  await window.pyodide.loadPackage("micromantid-1.1.0-cp312-cp312-pyodide_2024_0_wasm32.whl");
   // Copies files in the overrides folder to Python site-packages folder
   await window.pyodide.loadPackage("python-overrides-1.0.0-py2.py3-none-any.whl");
   await window.pyodide.loadPackage("mslice-1.0.0-py2.py3-none-any.whl");
@@ -131,7 +133,7 @@ async function init_python() {
      shortobj + '"icon": "favicon.ico", "path": "apps:/MSlice", "filename": "MSlice" }'
   +']');
   window.osjs.make('osjs/settings').set('osjs/desktop', 'iconview.enabled', true).save()
-  //url_to_fs("MAR25352_Ei180.00meV.nxspe", "/home/pyodide/MAR25352_Ei180.00meV.nxspe");
+  url_to_fs("MAR25352_Ei180.00meV.nxspe", "/home/pyodide/MAR25352_Ei180.00meV.nxspe");
 /*
   const exm = window.pyodide.runPython(`
     # Test script of all currently implemented widgets

--- a/src/inswae.js
+++ b/src/inswae.js
@@ -83,6 +83,17 @@ const init_osjs = () => {
   osjs.boot();
 };
 
+async function url_to_fs(urlpath, fspath) {
+  let xhr = new XMLHttpRequest();
+  xhr.open("GET", urlpath);
+  xhr.responseType = "arraybuffer";
+  xhr.send();
+  xhr.onload = () => { if (xhr.status == 200) { 
+    let arraybuf = new Uint8Array(xhr.response);
+    fs.writeFile(fspath, arraybuf);
+  } }
+};
+
 //window.addEventListener('DOMContentLoaded', () => init_osjs());
 async function init_python() {
   // Registers OS.js modules to be able to access them from Python
@@ -120,6 +131,7 @@ async function init_python() {
      shortobj + '"icon": "favicon.ico", "path": "apps:/MSlice", "filename": "MSlice" }'
   +']');
   window.osjs.make('osjs/settings').set('osjs/desktop', 'iconview.enabled', true).save()
+  //url_to_fs("MAR25352_Ei180.00meV.nxspe", "/home/pyodide/MAR25352_Ei180.00meV.nxspe");
 /*
   const exm = window.pyodide.runPython(`
     # Test script of all currently implemented widgets

--- a/src/mpl.css
+++ b/src/mpl.css
@@ -1,0 +1,84 @@
+/* General styling */
+.ui-helper-clearfix:before,
+.ui-helper-clearfix:after {
+  content: "";
+  display: table;
+  border-collapse: collapse;
+}
+.ui-helper-clearfix:after {
+  clear: both;
+}
+
+/* Header */
+.ui-widget-header {
+  border: 1px solid #dddddd;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  background: #e9e9e9;
+  color: #333333;
+  font-weight: bold;
+}
+
+/* Toolbar and items */
+.mpl-toolbar {
+  width: 100%;
+}
+
+.mpl-toolbar div.mpl-button-group {
+  display: inline-block;
+}
+
+.mpl-button-group + .mpl-button-group {
+  margin-left: 0.5em;
+}
+
+.mpl-widget {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  display: inline-block;
+  cursor: pointer;
+  color: #333;
+  padding: 6px;
+  vertical-align: middle;
+}
+
+.mpl-widget:disabled,
+.mpl-widget[disabled] {
+  background-color: #ddd;
+  border-color: #ddd !important;
+  cursor: not-allowed;
+}
+
+.mpl-widget:disabled img,
+.mpl-widget[disabled] img {
+  /* Convert black to grey */
+  filter: contrast(0%);
+}
+
+.mpl-widget.active img {
+  /* Convert black to tab:blue, approximately */
+  filter: invert(34%) sepia(97%) saturate(468%) hue-rotate(162deg) brightness(96%) contrast(91%);
+}
+
+button.mpl-widget:focus,
+button.mpl-widget:hover {
+  background-color: #ddd;
+  border-color: #aaa;
+}
+
+.mpl-button-group button.mpl-widget {
+  margin-left: -1px;
+}
+.mpl-button-group button.mpl-widget:first-child {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+  margin-left: 0px;
+}
+.mpl-button-group button.mpl-widget:last-child {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+select.mpl-widget {
+  cursor: default;
+}

--- a/src/mpl.js
+++ b/src/mpl.js
@@ -1,0 +1,58 @@
+class Figure {
+  constructor(id, div, width, height, title, toolbar) {
+    this.div = div;
+    this.div.id = id;
+    this.canvas = document.createElement("canvas");
+    this.canvas.id = id + "canvas";
+    var context = this.canvas.getContext('2d');
+    var backingStore =
+      context.backingStorePixelRatio ||
+      context.webkitBackingStorePixelRatio ||
+      context.mozBackingStorePixelRatio ||
+      context.msBackingStorePixelRatio ||
+      context.oBackingStorePixelRatio ||
+      context.backingStorePixelRatio ||
+      1;
+    this.ratio = (window.devicePixelRatio || 1) / backingStore;
+    // The top bar
+    var topbar = document.createElement("div");
+    topbar.id = id + "top";
+    topbar.setAttribute("style", "font-weight: bold; text-align: center");
+    topbar.textContent = title;
+    this.div.appendChild(topbar);
+    // Main canvas div with canvas and rubberband for toolbar etc
+    var canvas_div = document.createElement("div");
+    canvas_div.setAttribute("style", "position: relative");
+    this.canvas.setAttribute("width", width * this.ratio);
+    this.canvas.setAttribute("height", height * this.ratio);
+    this.canvas.setAttribute(
+      "style",
+      "left: 0; top: 0; z-index: 0; outline: 0; width:" + width + "px; height: " + height + "px");
+    canvas_div.appendChild(this.canvas);
+    var rubberband = document.createElement("canvas");
+    rubberband.id = id + "rubberband";
+    rubberband.setAttribute("width", width * this.ratio);
+    rubberband.setAttribute("height", height * this.ratio);
+    rubberband.setAttribute(
+      "style",
+      "position: absolute; left: 0; top: 0; z-index: 0; outline: 0; width: " + width + "px; height: " + height + "px");
+    // Canvas must have a "tabindex" attr in order to receive keyboard events
+    rubberband.setAttribute("tabindex", "0");
+    var rubber_context = rubberband.getContext("2d");
+    rubber_context.strokeStyle = "#000000";
+    rubber_context.setLineDash([2, 2]);
+    canvas_div.appendChild(rubberband);
+    this.div.appendChild(canvas_div);
+    // The bottom bar, with toolbar and message display
+    this.bottom = document.createElement("div");
+    this.bottom.id = id + "bottom";
+    this.message = document.createElement("div");
+    this.message.id = self._id + "message";
+    this.message.setAttribute("style", "min-height: 1.5em");
+    this.bottom.appendChild(this.message);
+    this.div.appendChild(this.bottom);
+  }
+}
+
+
+export const mpljs = { Figure }

--- a/src/mpl.js
+++ b/src/mpl.js
@@ -9,12 +9,12 @@ function simpleKeys(original) {
 };
     
 class Figure {
-  constructor(mplfig, div, width, height) {
+  constructor(mplfig, parent_element, width, height) {
     this.mplfig = mplfig;
-    this.div = div;
-    this.div.id = mplfig._id;
+    this.root = document.createElement('div');
+    this.root.setAttribute('style', 'display: inline-block');
+    parent_element.appendChild(this.root);
     this.canvas = document.createElement("canvas");
-    this.canvas.id = mplfig._id + "canvas";
     this.canvas.classList.add('mpl-canvas');
     this.canvas.setAttribute('style', 'box-sizing: content-box; pointer-events: none; position: relative; z-index: 0;');
     this.context = this.canvas.getContext('2d');
@@ -35,7 +35,7 @@ class Figure {
     this.header.setAttribute('style', 'width: 100%; text-align: center; padding: 3px;');
     this.header.textContent = mplfig._title;
     titlebar.appendChild(this.header);
-    this.div.appendChild(titlebar);
+    this.root.appendChild(titlebar);
     // Main canvas div with canvas and rubberband for toolbar etc
     this.canvas_div = document.createElement("div");
     this.canvas_div.setAttribute('tabindex', '0');
@@ -91,7 +91,7 @@ class Figure {
     });
     // Disable right mouse context menu.
     this.canvas_div.addEventListener('contextmenu', function (_e) { event.preventDefault(); return false; });
-    this.div.appendChild(this.canvas_div);
+    this.root.appendChild(this.canvas_div);
     // The bottom bar, with toolbar and message display
     this._toolbar_images = [];
     this.init_toolbar(this);
@@ -100,7 +100,7 @@ class Figure {
   init_toolbar() {
     toolbar = document.createElement('div');
     toolbar.classList = 'mpl-toolbar';
-    this.div.appendChild(toolbar);
+    this.root.appendChild(toolbar);
     var fig = this;
     function on_click_closure(name) {
         return function (_event) {
@@ -117,7 +117,6 @@ class Figure {
     this.buttons = {};
     var buttonGroup = document.createElement('div');
     var toolbar_items = this.mplfig.get_toolbar_items();
-    console.log(toolbar_items);
     buttonGroup.classList = 'mpl-button-group';
     for (var toolbar_ind in toolbar_items) {
         var name = toolbar_items[toolbar_ind][0];

--- a/src/mpl.js
+++ b/src/mpl.js
@@ -1,58 +1,269 @@
+function simpleKeys(original) {
+  // return a copy of an object with only non-object keys to avoid circular references
+  return Object.keys(original).reduce(function (obj, key) {
+    if (typeof original[key] !== 'object') {
+      obj[key] = original[key];
+    }
+    return obj;
+  }, {});
+};
+    
 class Figure {
-  constructor(id, div, width, height, title, toolbar) {
+  constructor(mplfig, div, width, height) {
+    this.mplfig = mplfig;
     this.div = div;
-    this.div.id = id;
+    this.div.id = mplfig._id;
     this.canvas = document.createElement("canvas");
-    this.canvas.id = id + "canvas";
-    var context = this.canvas.getContext('2d');
+    this.canvas.id = mplfig._id + "canvas";
+    this.canvas.classList.add('mpl-canvas');
+    this.canvas.setAttribute('style', 'box-sizing: content-box; pointer-events: none; position: relative; z-index: 0;');
+    this.context = this.canvas.getContext('2d');
     var backingStore =
-      context.backingStorePixelRatio ||
-      context.webkitBackingStorePixelRatio ||
-      context.mozBackingStorePixelRatio ||
-      context.msBackingStorePixelRatio ||
-      context.oBackingStorePixelRatio ||
-      context.backingStorePixelRatio ||
+      this.context.backingStorePixelRatio ||
+      this.context.webkitBackingStorePixelRatio ||
+      this.context.mozBackingStorePixelRatio ||
+      this.context.msBackingStorePixelRatio ||
+      this.context.oBackingStorePixelRatio ||
+      this.context.backingStorePixelRatio ||
       1;
     this.ratio = (window.devicePixelRatio || 1) / backingStore;
     // The top bar
-    var topbar = document.createElement("div");
-    topbar.id = id + "top";
-    topbar.setAttribute("style", "font-weight: bold; text-align: center");
-    topbar.textContent = title;
-    this.div.appendChild(topbar);
+    var titlebar = document.createElement('div');
+    titlebar.classList = 'ui-dialog-titlebar ui-widget-header ui-corner-all ui-helper-clearfix';
+    this.header = document.createElement('div');
+    this.header.classList = 'ui-dialog-title';
+    this.header.setAttribute('style', 'width: 100%; text-align: center; padding: 3px;');
+    this.header.textContent = mplfig._title;
+    titlebar.appendChild(this.header);
+    this.div.appendChild(titlebar);
     // Main canvas div with canvas and rubberband for toolbar etc
-    var canvas_div = document.createElement("div");
-    canvas_div.setAttribute("style", "position: relative");
+    this.canvas_div = document.createElement("div");
+    this.canvas_div.setAttribute('tabindex', '0');
+    this.canvas_div.setAttribute('style', 'border: 1px solid #ddd; box-sizing: content-box; clear:both;' +
+      'min-height: 1px; min-width: 1px; outline: 0; overflow: hidden; position: relative; resize: both; z-index: 2;');
     this.canvas.setAttribute("width", width * this.ratio);
     this.canvas.setAttribute("height", height * this.ratio);
-    this.canvas.setAttribute(
-      "style",
-      "left: 0; top: 0; z-index: 0; outline: 0; width:" + width + "px; height: " + height + "px");
-    canvas_div.appendChild(this.canvas);
-    var rubberband = document.createElement("canvas");
-    rubberband.id = id + "rubberband";
-    rubberband.setAttribute("width", width * this.ratio);
-    rubberband.setAttribute("height", height * this.ratio);
-    rubberband.setAttribute(
-      "style",
-      "position: absolute; left: 0; top: 0; z-index: 0; outline: 0; width: " + width + "px; height: " + height + "px");
-    // Canvas must have a "tabindex" attr in order to receive keyboard events
-    rubberband.setAttribute("tabindex", "0");
-    var rubber_context = rubberband.getContext("2d");
-    rubber_context.strokeStyle = "#000000";
-    rubber_context.setLineDash([2, 2]);
-    canvas_div.appendChild(rubberband);
-    this.div.appendChild(canvas_div);
+    //this.canvas.setAttribute("style", "left: 0; top: 0; z-index: 0; outline: 0; width:" + width + "px; height: " + height + "px");
+    this.canvas.classList.add('mpl-canvas');
+    this.canvas.setAttribute('style', 'box-sizing: content-box; pointer-events: none; position: relative; z-index: 0;');
+    this.canvas_div.appendChild(this.canvas);
+    // Rubberband for zoom/pan etc
+    this.rubberband_canvas = document.createElement('canvas');
+    this.rubberband_canvas.setAttribute('style', 'box-sizing: content-box; left: 0; pointer-events: none; position: absolute; top: 0; z-index: 1;');
+    this.rubberband_context = this.rubberband_canvas.getContext('2d');
+    this.rubberband_context.strokeStyle = '#000000';
+    this.rubberband_canvas.setAttribute('width', width * this.ratio);
+    this.rubberband_canvas.setAttribute('height', height * this.ratio);
+    this.canvas_div.appendChild(this.rubberband_canvas);
+    // Event handling
+    var fig = this; // Need to define this as var for closure below to work
+    function on_keyboard_event_closure(name) {
+      return function (event) {
+        return fig.key_event(event, name);
+      };
+    }
+    function on_mouse_event_closure(name) {
+      var UA = navigator.userAgent;
+      var isWebKit = /AppleWebKit/.test(UA) && !/Chrome/.test(UA);
+      if(isWebKit) {
+        return function (event) {
+          event.preventDefault();
+          return fig.mouse_event(event, name);
+        };
+      } else {
+        return function (event) {
+          return fig.mouse_event(event, name);
+        };
+      }
+    }
+    this.canvas_div.addEventListener('keydown', on_keyboard_event_closure('key_press'));
+    this.canvas_div.addEventListener('keyup', on_keyboard_event_closure('key_release'));
+    this.canvas_div.addEventListener('mousedown', on_mouse_event_closure('button_press'));
+    this.canvas_div.addEventListener('mouseup', on_mouse_event_closure('button_release'));
+    this.canvas_div.addEventListener('dblclick', on_mouse_event_closure('dblclick'));
+    // Throttle sequential mouse events to 1 every 20ms.
+    this.canvas_div.addEventListener('mousemove', on_mouse_event_closure('motion_notify'));
+    this.canvas_div.addEventListener('mouseenter', on_mouse_event_closure('figure_enter'));
+    this.canvas_div.addEventListener('mouseleave', on_mouse_event_closure('figure_leave'));
+    this.canvas_div.addEventListener('wheel', function (event) {
+      if (event.deltaY < 0) { event.step = 1; } else { event.step = -1; }
+      on_mouse_event_closure('scroll')(event);
+    });
+    // Disable right mouse context menu.
+    this.canvas_div.addEventListener('contextmenu', function (_e) { event.preventDefault(); return false; });
+    this.div.appendChild(this.canvas_div);
     // The bottom bar, with toolbar and message display
-    this.bottom = document.createElement("div");
-    this.bottom.id = id + "bottom";
-    this.message = document.createElement("div");
-    this.message.id = self._id + "message";
-    this.message.setAttribute("style", "min-height: 1.5em");
-    this.bottom.appendChild(this.message);
-    this.div.appendChild(this.bottom);
-  }
-}
+    this._toolbar_images = [];
+    this.init_toolbar(this);
+  };
 
+  init_toolbar() {
+    toolbar = document.createElement('div');
+    toolbar.classList = 'mpl-toolbar';
+    this.div.appendChild(toolbar);
+    var fig = this;
+    function on_click_closure(name) {
+        return function (_event) {
+            return fig.toolbar_button_onclick(name);
+        };
+    }
+    function on_mouseover_closure(tooltip) {
+        return function (event) {
+            if (!event.currentTarget.disabled) {
+                return fig.toolbar_button_onmouseover(tooltip);
+            }
+        };
+    }
+    this.buttons = {};
+    var buttonGroup = document.createElement('div');
+    var toolbar_items = this.mplfig.get_toolbar_items();
+    console.log(toolbar_items);
+    buttonGroup.classList = 'mpl-button-group';
+    for (var toolbar_ind in toolbar_items) {
+        var name = toolbar_items[toolbar_ind][0];
+        var tooltip = toolbar_items[toolbar_ind][1];
+        var image = toolbar_items[toolbar_ind][2];
+        var method_name = toolbar_items[toolbar_ind][3];
+        if (!name) {
+            /* Instead of a spacer, we start a new button group. */
+            if (buttonGroup.hasChildNodes()) {
+                toolbar.appendChild(buttonGroup);
+            }
+            buttonGroup = document.createElement('div');
+            buttonGroup.classList = 'mpl-button-group';
+            continue;
+        }
+        var button = (this.buttons[name] = document.createElement('button'));
+        button.classList = 'mpl-widget';
+        button.setAttribute('role', 'button');
+        button.setAttribute('aria-disabled', 'false');
+        button.addEventListener('click', on_click_closure(method_name));
+        button.addEventListener('mouseover', on_mouseover_closure(tooltip));
+        var icon_img = new Image();
+        this._toolbar_images.push(icon_img)
+        const image_bytes = this.mplfig.get_toolbar_image(image);
+        const blob = new Blob([image_bytes], { type: 'image/png' });
+        icon_img.src = (window.URL || window.webkitURL).createObjectURL(blob);
+        icon_img.alt = tooltip;
+        button.appendChild(icon_img);
+        buttonGroup.appendChild(button);
+    }
+    if (buttonGroup.hasChildNodes()) {
+        toolbar.appendChild(buttonGroup);
+    }
+    var fmt_picker = document.createElement('select');
+    fmt_picker.classList = 'mpl-widget';
+    toolbar.appendChild(fmt_picker);
+    this.format_dropdown = fmt_picker;
+    var extensions = ["eps", "jpeg", "pdf", "pgf", "png", "ps", "raw", "svg", "tif"];
+    var default_extension = "png";
+    for (var ind in extensions) {
+        var fmt = extensions[ind];
+        var option = document.createElement('option');
+        option.selected = fmt === default_extension;
+        option.innerHTML = fmt;
+        fmt_picker.appendChild(option);
+    }
+    this.message = document.createElement('span');
+    this.message.classList = 'mpl-message';
+    toolbar.appendChild(this.message);
+  };
+
+  mouse_event(event, name) {
+    if (name === 'button_press') {
+        this.canvas.focus();
+        this.canvas_div.focus();
+    }
+    // from https://stackoverflow.com/q/1114465
+    var boundingRect = this.canvas.getBoundingClientRect();
+    var x = (event.clientX - boundingRect.left) * this.ratio;
+    var y = (event.clientY - boundingRect.top) * this.ratio;
+    function getModifiers(event) {
+      var mods = [];
+      if (event.ctrlKey) { mods.push('ctrl'); }
+      if (event.altKey) { mods.push('alt'); }
+      if (event.shiftKey) { mods.push('shift'); }
+      if (event.metaKey) { mods.push('meta'); }
+      return mods;
+    };
+    this.mplfig.handle_mouse(name, x, y, event.button, event.step, getModifiers(event), simpleKeys(event));
+    return false;
+  };
+
+  key_event(event, name) {
+    // Prevent repeat events
+    if (name === 'key_press') {
+      if (event.key === this._key) {
+        return;
+      } else {
+        this._key = event.key;
+      }
+    }
+    if (name === 'key_release') {
+      this._key = null;
+    }
+    var value = '';
+    if (event.ctrlKey && event.key !== 'Control') {
+      value += 'ctrl+'; }
+    else if (event.altKey && event.key !== 'Alt') {
+      value += 'alt+'; }
+    else if (event.shiftKey && event.key !== 'Shift') {
+      value += 'shift+'; }
+    value += 'k' + event.key;
+    this.mplfig.handle_key(name, value, simpleKeys(event));
+    return false;
+  };
+
+  toolbar_button_onclick(name) {
+    if (name === 'download') {
+      var format = this.format_dropdown.options[this.format_dropdown.selectedIndex].value;
+      this.mplfig.handle_save(format);
+    } else {
+      this.mplfig.handle_toolbar_button(name);
+    }
+  };
+
+  toolbar_button_onmouseover(tooltip) {
+    this.message.textContent = tooltip;
+  };
+
+  handle_message(msg) {
+    this.message.textContent = msg['message'];
+  };
+
+  handle_rubberband(x0, x1, y0, y1) {
+    x0 = Math.floor(x0 / this.ratio) + 0.5;
+    y0 = Math.floor((this.canvas.height - y0) / this.ratio) + 0.5;
+    x1 = Math.floor(x1 / this.ratio) + 0.5;
+    y1 = Math.floor((this.canvas.height - y1) / this.ratio) + 0.5;
+    var min_x = Math.min(x0, x1);
+    var min_y = Math.min(y0, y1);
+    var width = Math.abs(x1 - x0);
+    var height = Math.abs(y1 - y0);
+    this.rubberband_context.clearRect(0, 0, this.canvas.width / this.ratio, this.canvas.height / this.ratio);
+    this.rubberband_context.strokeRect(min_x, min_y, width, height);
+  };
+
+  handle_history_buttons(back, forward) {
+    this.buttons['Back'].disabled = !back;
+    this.buttons['Back'].setAttribute('aria-disabled', !back);
+    this.buttons['Forward'].disabled = !forward;
+    this.buttons['Forward'].setAttribute('aria-disabled', !forward);
+  };
+
+  handle_navigate_mode(mode) {
+    if (mode === 'PAN') {
+        this.buttons['Pan'].classList.add('active');
+        this.buttons['Zoom'].classList.remove('active');
+    } else if (mode === 'ZOOM') {
+        this.buttons['Pan'].classList.remove('active');
+        this.buttons['Zoom'].classList.add('active');
+    } else {
+        this.buttons['Pan'].classList.remove('active');
+        this.buttons['Zoom'].classList.remove('active');
+    }
+  };
+
+};
 
 export const mpljs = { Figure }

--- a/src/patch_mantid.js
+++ b/src/patch_mantid.js
@@ -17,7 +17,7 @@ const patches = fs.readdirSync(diffdir).map(
 // Copies original files over and patch them if needed
 fs.readdirSync(srcdir, { recursive: true }).map(
   file => {
-    const destfile = destdir + '/' + file;
+    const destfile = destdir + '/' + file.replaceAll('\\', '/');
     const subdir = path.dirname(destfile);
     if (!fs.existsSync(subdir)) {
       try {


### PR DESCRIPTION
Bugfixes from ICNS and additional code for release 0.3.0 for the Mantid developers meeting

* Updated MSlice and Mantid to 6.14 (micromantid-1.1)
* Add own matplotlib backend which uses code from official `webagg` backend but with direct pyodide interface like `matplotlib-pyodide` with the tornado or simulated websockets.
* Back-end has working toolbar and works with MSlice but does not have resize. Old matplotlib-pyodide did not have working toolbar but `webagg` did not work with MSlice.
* Add function to copy a url to virtual filesystem to have the Al dataset automatically loaded for MSlice.
* Fix minor bugs and warnings - now if window is closed can reopen them by launching the app again / making the same MSlice plot.